### PR TITLE
Add organisation-wide community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: 🐛 Bug report
+description: Something isn't working as expected
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! If you're not sure which repo
+        is right, pick the frontend you were using. See the platform status at
+        https://dasher.at/status/.
+  - type: dropdown
+    id: repo
+    attributes:
+      label: Repository / Frontend
+      options:
+        - DasherCore (engine)
+        - Dasher-Apple (iOS / macOS / visionOS)
+        - Dasher-Windows (Avalonia)
+        - Dasher-GTK (Linux)
+        - website (dasher.at)
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Dasher version
+      placeholder: e.g. 1.0.0, 0.1.0-preview3, or a commit SHA
+  - type: input
+    id: platform
+    attributes:
+      label: Platform & OS
+      placeholder: e.g. macOS 14.4, Windows 11, Ubuntu 24.04, iPadOS 17
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Steps to reproduce, what you expected, and what actually happened.
+      placeholder: |
+        1. Open Dasher
+        2. ...
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Anything in the console, dasher.log, or a screenshot. Paste between triple backticks.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📚 Developer handbook
+    url: https://dasher.at/developers/
+    about: Architecture, build guides, the feature matrix and how to propose changes.
+  - name: 💬 Dasher Slack
+    url: https://dasher.at/
+    about: Questions and chat — ask a maintainer for a Slack invite.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: ✨ Feature request
+description: Suggest a new capability or improvement
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the _behaviour_ you want, not just the implementation on one
+        platform. If this should exist on multiple platforms, consider opening a
+        **Platform parity** issue instead so we can track it everywhere.
+  - type: textarea
+    id: story
+    attributes:
+      label: User story
+      description: "As a … I want … so that …"
+      placeholder: As an eye-gaze user, I want … so that …
+    validations:
+      required: true
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Which platform(s)?
+      multiple: true
+      options:
+        - All platforms (parity)
+        - DasherCore (engine)
+        - Apple (iOS / macOS / visionOS)
+        - Windows (Avalonia)
+        - GTK (Linux)
+        - Android
+        - Web
+    validations:
+      required: true
+  - type: input
+    id: core-dep
+    attributes:
+      label: DasherCore dependency (if known)
+      placeholder: e.g. requires a new C API callback / V6 event stream
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/platform-parity.yml
+++ b/.github/ISSUE_TEMPLATE/platform-parity.yml
@@ -1,0 +1,43 @@
+name: ↔️ Platform parity
+description: Track a capability across all Dasher frontends
+title: 'Parity: <capability name>'
+labels: ['parity']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to track a single capability across every frontend.
+        When the status changes, update the comment and (ideally) the feature
+        matrix at `website/src/data/feature-status.yaml` (rendered at
+        https://dasher.at/status/).
+  - type: input
+    id: category
+    attributes:
+      label: Category
+      placeholder: Input / Rendering / Language / Output / Settings / Onboarding / Accessibility / Game Mode
+    validations:
+      required: true
+  - type: input
+    id: core-dep
+    attributes:
+      label: DasherCore dependency
+      placeholder: e.g. V6 calibration API, pointer event stream
+    validations:
+      required: true
+  - type: textarea
+    id: matrix
+    attributes:
+      label: Status per platform
+      description: One line per platform. Status options: shipped / beta / planned / not-supported / n/a
+      placeholder: |
+        - Apple:   shipped (v1.0)
+        - Windows: beta (issue #123)
+        - GTK:     not-supported (OS limitation)
+        - Android: planned
+        - Web:     shipped
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / design reference

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What does this change do, and why? Link any issue / RFC. -->
+
+Issue / RFC: #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Cross-platform / parity change
+- [ ] Refactor / tooling / docs
+
+## Cross-platform impact
+
+A core goal of Dasher v6 is **feature parity** across frontends. Help reviewers
+see the blast radius:
+
+- [ ] This changes a capability that users see on **other platforms**.
+      If checked, I have opened / updated the feature matrix
+      (`website/src/data/feature-status.yaml`) — linked PR: #
+      _(or confirmed this is genuinely platform-specific-only)_
+- [ ] This introduces a **new UX or hardware interaction**.
+      If checked, an RFC (`governance/rfcs`) is linked: #
+
+## Definition of Done
+
+- [ ] CI is green (build + tests + lint + format, as applicable)
+- [ ] Tests added for new behaviour
+- [ ] Feature matrix updated if this affects a cross-platform capability
+- [ ] Docs / changelog updated if the change is user-facing

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+The Dasher Project follows the Contributor Covenant v2.1.
+
+**The canonical, authoritative text lives in our governance repository:**
+<https://github.com/dasher-project/governance/blob/main/code-of-conduct.md>
+
+This Code of Conduct applies on any communication or interaction across **all**
+Dasher Project repositories, issues, pull requests, and our Slack workspace.
+
+## Reporting
+
+To report a violation, contact the stewards responsible for enforcement:
+
+- **Gavin Henderson** — ghenderson@acecentre.org.uk
+- **Will Wade** — wwade@acecentre.org.uk
+
+…or reach out privately on the Dasher Slack. Reports are handled confidentially
+using the enforcement ladder described in the full text linked above.
+
+_The full text is intentionally not duplicated here so it cannot drift out of
+sync. Always refer to the governance repository for the current version._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to the Dasher Project
+
+First off — thank you for wanting to contribute to Dasher! Dasher is a
+predictive, continuous-gesture text-entry system used worldwide as an
+assistive tool (eye-gaze, head-trackers, switches, joysticks and more).
+This guide gets you started; the full developer handbook lives at
+**<https://dasher.at/developers/>**.
+
+## The big picture
+
+Dasher v6 is one **shared engine** consumed by several **native frontends**:
+
+| Repository | Platform | UI stack | DasherCore integration |
+| --- | --- | --- | --- |
+| [`DasherCore`](https://github.com/dasher-project/DasherCore) | All | C++ engine + C API | _is_ the engine |
+| [`Dasher-Apple`](https://github.com/dasher-project/Dasher-Apple) | iOS / macOS / visionOS | SwiftUI | compiled core + C API header |
+| [`Dasher-Windows`](https://github.com/dasher-project/Dasher-Windows) | Windows | Avalonia (.NET) | `dasher.dll` via P/Invoke |
+| [`Dasher-GTK`](https://github.com/dasher-project/Dasher-GTK) | Linux (+ Win/macOS fallback) | GTK4 / gtkmm | `libdasher.so` linked |
+| [`website`](https://github.com/dasher-project/website) | Web | Astro | docs + public status |
+
+Before touching a frontend, read **[DasherCore's C API contract](https://github.com/dasher-project/DasherCore/blob/main/docs/C_API.md)**
+and the **[cross-platform feature matrix](https://dasher.at/status/)** — it
+shows what every platform already supports so we keep parity.
+
+## Where to go next
+
+- **Building a specific platform:** see the developer handbook at <https://dasher.at/developers/> and the `README.md` / `CONTRIBUTING.md` inside the relevant repo.
+- **Coding standards:** [`DasherCore/CONTRIBUTING.md`](https://github.com/dasher-project/DasherCore/blob/main/CONTRIBUTING.md) is the project's gold standard (no naked `new`/`delete`, `const`-correctness, zero warnings, clean API boundaries). Each frontend repo states its own language-specific rules.
+- **Design tokens:** the normative source of truth is [`dasher-design-guide/DESIGN.md`](https://github.com/dasher-project/dasher-design-guide/blob/main/DESIGN.md).
+- **Proposing a cross-platform change:** read the [RFC process](https://github.com/dasher-project/governance#decision-making) in our governance repo.
+
+## Definition of Done
+
+A pull request is ready to merge when:
+
+- [ ] CI is green (build + tests + lint + format, as applicable to the repo).
+- [ ] New behaviour has tests.
+- [ ] If the change affects a cross-platform capability, the **feature matrix** (`website/src/data/feature-status.yaml`) has been updated in this or a linked PR.
+- [ ] If the change is a new UX/hardware interaction, an **RFC** is linked.
+- [ ] Docs / changelog are updated if the change is user-facing.
+
+## Quick expectations
+
+- **Be kind.** Our [Code of Conduct](./CODE_OF_CONDUCT.md) applies across every Dasher repository and our Slack.
+- **Open a PR, not a direct push.** Reviews are required on `main`.
+- **Small, focused PRs** are easier to review and land faster.
+- **Talk to us first** for big changes — open an issue or an RFC.
+
+_This file is the organisation-wide default. Individual repositories may add their own `CONTRIBUTING.md` with platform-specific build steps and rules, which take precedence here._

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Dasher is assistive software relied on by people for daily communication, so
+we take security reports seriously.
+
+**Please do not open a public GitHub issue for security problems.**
+
+Instead, report vulnerabilities privately:
+
+1. Use GitHub's **"Report a vulnerability"** feature (the **Security** tab →
+   "Report a vulnerability" on the relevant repository), _or_
+2. Email the stewards: **ghenderson@acecentre.org.uk** and
+   **wwade@acecentre.org.uk**.
+
+Please include:
+
+- The repository affected (e.g. `DasherCore`, `Dasher-Apple`).
+- A description of the issue and its impact.
+- Steps to reproduce, and any proof-of-concept.
+
+## Scope
+
+This policy covers all repositories under the
+[`dasher-project`](https://github.com/dasher-project) organisation that are
+**not** archived. Reports about dependencies should be filed upstream.
+
+## Response
+
+We will acknowledge reports within **5 business days** and aim to issue a fix
+or mitigation within **30 days** for verified issues, coordinated with the
+reporter on disclosure timing.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,19 @@
+# Support
+
+## Using Dasher (end users)
+
+- **Documentation & install guides:** <https://dasher.at/docs/>
+- **Downloads:** <https://dasher.at/downloads/>
+- **FAQ:** <https://dasher.at/faq/>
+
+## For developers
+
+- **Developer handbook:** <https://dasher.at/developers/>
+- **Feature / platform status:** <https://dasher.at/status/>
+- **Found a bug or want a feature?** Open an issue in the relevant
+  [repository](https://github.com/dasher-project).
+
+## Community
+
+Join the conversation on the **Dasher Slack** — invite link in each repo's
+README, or ask a maintainer.


### PR DESCRIPTION
## Why

The `dasher-project` org currently has **no** org-level health files (this `.github` repo only held a profile README), so GitHub has nothing to fall back on for the frontend repos — and the audit showed none of Dasher-Apple / Dasher-Windows / Dasher-GTK have their own CONTRIBUTING, PR/issue templates, CoC, or SECURITY either.

This PR adds the inherited defaults that GitHub auto-applies to every repo that doesn't define its own — instant baseline coverage for the whole org.

## What
- `CONTRIBUTING.md` — entry point + the big-picture architecture table + **Definition of Done**, links to the handbook and DasherCore's gold-standard CONTRIBUTING.
- `CODE_OF_CONDUCT.md` — points to the canonical text in `governance/code-of-conduct.md` (no duplication → no drift).
- `SECURITY.md` — private vulnerability reporting workflow.
- `SUPPORT.md` — end-user vs developer routing.
- `.github/PULL_REQUEST_TEMPLATE.md` — includes the **cross-platform parity checkbox** and the **RFC checkbox**.
- `.github/ISSUE_TEMPLATE/{bug,feature,platform-parity}.yml` + `config.yml` — structured forms; a dedicated **platform-parity** issue type to track capabilities across frontends.

## Related
Part of the cross-platform parity / contributor-experience unification. The handbook + public status matrix these files link to land in the `website` repo separately.
