### PR TITLE
Rewrite org profile README

### DIFF
--- a/profile/readme.md
+++ b/profile/readme.md
@@ -51,5 +51,5 @@ Contributions are welcome! See the
 for project-wide conventions, and each repo's own `CONTRIBUTING.md` for
 platform-specific build instructions.
 
-Dasher is maintained by the [Ace Centre](https://acecentre.org.uk/) charity
-and licensed under MIT (v6) or GPL-2.0 (v5), depending on the repository.
+Dasher is maintained by Will Wade and the dasher-project team, and is
+licensed under MIT (v6) or GPL-2.0 (v5), depending on the repository.

--- a/profile/readme.md
+++ b/profile/readme.md
@@ -1,50 +1,55 @@
-# Dasher project code repositories
-Welcome to the Dasher project code repositories currently maintained by the
-Will Wade and the dasher-project team. 
+# Dasher
 
-Dasher is an alternative text entry system that may replace an on-screen
-keyboard or be used as an Alternative and Augmentative Communication tool. For
-information on Dasher and the latest Dasher apps see its
-[home page on the Dasher Website](https://dasher.at).
+Dasher is a zooming predictive text-entry system for accessibility and
+augmentative communication (AAC). It lets you write using minimal physical
+input — eye gaze, a mouse, a single switch, a joystick, or touch.
 
--   [Governance Documents](https://github.com/dasher-project/governance/)  
-    The official governance model for all the projects here.
-    
--   [Dasher Version 5](https://github.com/dasher-project/dasher/)  
-    Fork of the Dasher repository maintained by the GNOME project. The code is
-    GPL-2.0 licensed, same as the original Dasher. The programming language is
-    C++.
+> **Looking for apps, downloads, or user docs?** Visit
+> **[dasher.at](https://dasher.at)** — that's the end-user website.
 
--   [Dasher relicensed](https://github.com/dasher-project/dasher-MIT/)  
-    Dasher implementation that is MIT licensed, under stewardship of Ace Centre.
-    The repository was started by relicensing some of the C++ code in the GNOME
-    repository. An explanation of the relicensing process can be found in the
-    repository.
+## Active development (v6)
 
--   [DasherCore](https://github.com/dasher-project/DasherCore)  
-    A tiedied up and modernized version of the Dasher relicensed repository.
-    All UI-components were strippend to create a Dasher library that can be
-    attached to all kinds of front-ends
+Dasher v6 is **one shared engine** consumed by **native frontends**. Each
+frontend owns only input, rendering, and platform UI; all the prediction logic
+lives in the engine.
 
--   [Dasher GTK](https://github.com/dasher-project/Dasher-GTK)  
-    A front-end for the modernized DasherCore based on GTK that is in active
-    development to replace the Dasher Version 5 at some point in the future.
+| Repository                                                                                             | What it is                              | Tech            |
+| :----------------------------------------------------------------------------------------------------- | :-------------------------------------- | :-------------- |
+| [DasherCore](https://github.com/dasher-project/DasherCore)                                             | The engine — language models, rendering maths, settings, alphabets, flat C API | C++17           |
+| [Dasher-Apple](https://github.com/dasher-project/Dasher-Apple)                                         | iOS, macOS, visionOS apps + keyboard extension        | SwiftUI         |
+| [Dasher-Windows](https://github.com/dasher-project/Dasher-Windows)                                     | Windows desktop app                                 | Avalonia (.NET) |
+| [Dasher-GTK](https://github.com/dasher-project/Dasher-GTK)                                             | Linux desktop app (cross-platform build)            | GTK4 / gtkmm    |
+| [dasher-design-guide](https://github.com/dasher-project/dasher-design-guide)                           | Design tokens, settings structure, parity spec      | Markdown        |
+| [website](https://github.com/dasher-project/website)                                                   | Source code for [dasher.at](https://dasher.at)     | Astro           |
 
--   [Dasher Windows](https://github.com/dasher-project/Dasher-Windows)  
-    A front-end for the modernized DasherCore based on Avalonia.
-    
--   [Dasher Apple](https://github.com/dasher-project/Dasher-Apple)  
-    A front-end for the modernized DasherCore based on SwiftUI. For iOS, MacOS, VisionOS
+### For developers
 
--   [Dasher Design Guide for v6](https://github.com/dasher-project/dasher-design-guide)  
-    A front-end for the modernized DasherCore based on SwiftUI. For iOS, MacOS, VisionOS
+- **[Developer handbook](https://dasher.at/developers/)** — architecture, build guides, contributing, RFCs
+- **[Feature status matrix](https://dasher.at/status/)** — what each platform supports (v6 + v5 baseline)
+- **[Integrating DasherCore](https://dasher.at/docs/development/)** — C API, pre-built binaries
+- **[Governance & RFCs](https://github.com/dasher-project/governance)** — decision process
 
--   [Dasher in Web Technologies](https://github.com/dasher-project/dasher-web)  
-    This is the DasherCore in WASM showing how we can do use this for the web. NOTE: there is historic data in branches of JS only approaches. 
+### Web demo
 
-## Archived
+[dasher-web](https://github.com/dasher-project/dasher-web) — DasherCore
+compiled to WASM. Powers the live demo on the
+[homepage](https://dasher.at). Available for anyone who wants to embed Dasher
+on the web.
 
--   [Dasher custom keyboards for Android and iOS](https://github.com/dasher-project/dasher-captivewebview/)  
-    Instances of Dasher in Web Technologies, above, that can be used for text
-    entry in any Android or iOS app. MIT licensed.
+## Legacy & archived
 
+| Repository                                                                                                 | Status  | Notes                                                    |
+| :--------------------------------------------------------------------------------------------------------- | :------ | :------------------------------------------------------- |
+| [dasher](https://github.com/dasher-project/dasher)                                                         | Stable  | Dasher 5.x (GPL-2.0). GNOME-era C++ codebase.            |
+| [dasher-MIT](https://github.com/dasher-project/dasher-MIT)                                                 | Legacy  | MIT-licensed predecessor to DasherCore.                  |
+| [dasher-captivewebview](https://github.com/dasher-project/dasher-captivewebview)                           | Archived | Android/iOS keyboard wrappers using dasher-web.          |
+
+## Contributing
+
+Contributions are welcome! See the
+[contributing guide](https://github.com/dasher-project/.github/blob/main/.github/CONTRIBUTING.md)
+for project-wide conventions, and each repo's own `CONTRIBUTING.md` for
+platform-specific build instructions.
+
+Dasher is maintained by the [Ace Centre](https://acecentre.org.uk/) charity
+and licensed under MIT (v6) or GPL-2.0 (v5), depending on the repository.


### PR DESCRIPTION
Clear v6/legacy split, fix typos, fix design guide copy-paste error, add website repo, add developer links (handbook, status, governance), add tech stack column.