### PR TITLE
Add frontend README template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ shows what every platform already supports so we keep parity.
 
 ## Where to go next
 
-- **Building a specific platform:** see the developer handbook at <https://dasher.at/developers/> and the `README.md` / `CONTRIBUTING.md` inside the relevant repo.
+- **Building a specific platform:** see the developer handbook at <https://dasher.at/developers/> and the `README.md` / `CONTRIBUTING.md` inside the relevant repo. Frontend repos should follow the [README template](./README-TEMPLATE.md).
 - **Coding standards:** [`DasherCore/CONTRIBUTING.md`](https://github.com/dasher-project/DasherCore/blob/main/CONTRIBUTING.md) is the project's gold standard (no naked `new`/`delete`, `const`-correctness, zero warnings, clean API boundaries). Each frontend repo states its own language-specific rules.
 - **Design tokens:** the normative source of truth is [`dasher-design-guide/DESIGN.md`](https://github.com/dasher-project/dasher-design-guide/blob/main/DESIGN.md).
 - **Proposing a cross-platform change:** read the [RFC process](https://github.com/dasher-project/governance#decision-making) in our governance repo.

--- a/README-TEMPLATE.md
+++ b/README-TEMPLATE.md
@@ -1,0 +1,108 @@
+# Dasher Frontend README Template
+
+Each `Dasher-<Platform>` repository's `README.md` should follow this structure.
+Copy it, replace the `<...>` placeholders, and adapt the platform-specific
+sections. Keep it concise — link out to [dasher.at](https://dasher.at) and
+[DasherCore](https://github.com/dasher-project/DasherCore) for depth rather
+than duplicating their content.
+
+---
+
+```markdown
+# Dasher for <Platform>
+
+[![Build](<ci-badge-url>)](<ci-link>) [![Release](<release-badge-url>)](<release-link>) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
+Dasher is an information-efficient text-entry interface, driven by continuous
+pointing gestures. It lets you write using eye gaze, a mouse, a switch, a
+joystick, or touch — designed for accessibility and augmentative communication
+(AAC).
+
+This is the **<Platform>** frontend, built on the shared
+[DasherCore](https://github.com/dasher-project/DasherCore) engine.
+
+> **[dasher.at](https://dasher.at)** — downloads, user docs, and live demo
+> **[Feature status](https://dasher.at/status/)** — what each platform supports
+> **[All repos](https://github.com/dasher-project)** — engine, frontends, design guide
+
+## Status
+
+> **<Phase/Release status>** — <one line>. See the
+> [feature matrix](https://dasher.at/status/) for what's implemented.
+
+## Install
+
+<Platform app store link, or "Download the latest build from
+[Releases](../../releases)", or "Not yet publicly available".>
+
+## Build
+
+### Prerequisites
+
+- <tool 1 + version>
+- <tool 2 + version>
+- Git (with submodules)
+
+### Steps
+
+```bash
+git clone --recurse-submodules https://github.com/dasher-project/Dasher-<Platform>.git
+cd Dasher-<Platform>
+<build command>
+```
+
+<If the build has multiple phases (native layer + UI layer), number them
+like the Dasher-Windows README does.>
+
+<If the frontend supports multiple host OSes for development, include a
+dependency table like the Dasher-GTK README.>
+
+## Architecture
+
+<One paragraph: how DasherCore is consumed (Pattern A: direct C++ subclassing,
+Pattern B: C API via FFI/JNI/P-Invoke, or WASM) and what this repo provides.>
+
+```
+<concise ASCII diagram of the data flow — see Dasher-Windows for the best example>
+```
+
+See [DasherCore's C API](https://github.com/dasher-project/DasherCore/blob/main/docs/C_API.md)
+for the engine contract.
+
+## Repository layout
+
+| Path | Purpose |
+|---|---|
+| `<dir>/` | <what it does> |
+| `third_party/DasherCore/` | DasherCore submodule (do not edit here — PR upstream) |
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for build details, code style, and
+DCO sign-off. For project-wide conventions (code of conduct, RFCs, security),
+see the
+[org contributing guide](https://github.com/dasher-project/.github/blob/main/CONTRIBUTING.md).
+
+## License
+
+MIT — see [LICENSE](./LICENSE).
+```
+
+---
+
+## Guidance
+
+- **Opening:** use the two-sentence intro verbatim (do not rewrite it per
+  repo — consistency helps search and first impressions).
+- **Badges:** at minimum a CI badge and a license badge. Add a release/store
+  badge if the platform has one (TestFlight, Google Play, Flatpak, etc.).
+- **Status blockquote:** be honest about maturity. Link to the feature matrix
+  rather than summarising it inline.
+- **Build:** copy-paste blocks that work when pasted into a terminal. Number
+  multi-phase builds. If a manual step is unavoidable (copy a DLL, set a
+  PATH), say so explicitly — don't hide it.
+- **Architecture:** keep it to one paragraph + one diagram. Link to DasherCore
+  for the full C API contract. Don't duplicate DasherCore's docs.
+- **What NOT to include:** a long "what is Dasher?" explainer (link dasher.at),
+  the v5 "PDAs" boilerplate, full RFC summaries (link governance), or the
+  feature matrix table (it lives on the website).


### PR DESCRIPTION
Standardised README structure for all Dasher-<Platform> repos, synthesised from the best parts of existing READMEs (Apple's intro, Windows' architecture diagram, GTK's dependency table, Android's status blockquote, dasher-web's badges).

Not an RFC — it's a documentation convention. Each frontend copies and adapts it.

CONTRIBUTING.md updated to link to it.